### PR TITLE
Enable User Service Deployment to take in env vars via Kubernetes Secrets

### DIFF
--- a/gke/user-service-deployment.yaml
+++ b/gke/user-service-deployment.yaml
@@ -25,7 +25,17 @@ spec:
               cpu: 40m
               memory: 100Mi
           env:
-            - name: DB_CLOUD_URI
-              value: mongodb+srv://yongxiangng:p6F9nkFmMDtgkGgF@cluster0.ivtwevt.mongodb.net/user-service
             - name: ENV
               value: PROD
+            - name: DB_CLOUD_URI
+              secretKeyRef:
+                name: user-service-secret
+                key: DB_CLOUD_URI
+            - name: JWT_ACCESS_SECRET
+              secretKeyRef:
+                name: user-service-secret
+                key: JWT_ACCESS_SECRET
+            - name: JWT_REFRESH_SECRET
+              secretKeyRef:
+                name: user-service-secret
+                key: JWT_REFRESH_SECRET

--- a/user-service/.gitignore
+++ b/user-service/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Kubernetes Secret txt file
+user-svc-secrets.txt

--- a/user-service/.gitignore
+++ b/user-service/.gitignore
@@ -104,4 +104,4 @@ dist
 .tern-port
 
 # Kubernetes Secret txt file
-user-svc-secrets.txt
+user-service-secret.txt


### PR DESCRIPTION
resolves #28
Actions taken:
1. Manually created secret in GKE cluster via command "kubectl create secret generic user-service-secret --from-env-file user-service-secret.txt". Note that the MongoDB Atlas URL is now Zhen Teng's url
2. Modified /gke/user-service-deployment.yaml to take in environment variables via the created Secret