### PR TITLE
Enable password reset via email push

### DIFF
--- a/user-service/controller/pwd-reset-controller.js
+++ b/user-service/controller/pwd-reset-controller.js
@@ -1,0 +1,72 @@
+import { ormGetUser as _getUser } from '../model/user-orm.js'
+import { ormCreatePwdResetRequest as _createPwdResetRequest } from '../model/pwd-reset-orm.js'
+import { ormGetPwdResetRequest as _getPwdResetRequest } from '../model/pwd-reset-orm.js'
+
+import sgMail from '@sendgrid/mail'
+
+sgMail.setApiKey(process.env.SENDGRID_API_KEY)
+const emailRegex = RegExp("\\S+@\\S+\\.\\S+")
+
+function generateEmailMessage(recipientEmail, username, pwdResetUrl) {
+    const body = 'You have requested to reset the password for the PeerPrep account with username: ' + username +'. \n Please click on the following link to do so.';
+    const userSvcSenderEmail = process.env.USER_SVC_SENDER_EMAIL
+    return {
+        to: recipientEmail,
+        from: userSvcSenderEmail,
+        subject: 'PeerPrep account password reset request',
+        html: `<strong>Greetings from Peer Prep Scammers!</strong><body><p>${body}</p></body><body><p>Click to set a new password : <a href="${pwdResetUrl}">Reset password</a></p></body>`,
+    };
+}
+
+export async function sendPasswordResetEmail(req, res) {
+    // using Twilio SendGrid's v3 Node.js Library
+    // https://github.com/sendgrid/sendgrid-nodejs
+    const username = req.body.username
+    const email = req.body.email
+    if (username && email) {
+        if (!emailRegex.test(email)) {
+            return res.status(400).json({message: 'Could not reset password, email format invalid. Email has to contain the @ and . character', success:false});
+        }
+        const existingUser = await _getUser(username)
+        var userEmail
+        if (existingUser) {
+            userEmail = existingUser.email
+            if (!userEmail) {
+                return res.status(500).json({message: "No email address for specified user", success:false})
+            }
+            if (userEmail != email) {
+                return res.status(400).json({message: "Email address does not match database records", success:false})
+            }
+            // username and email match
+            // add entry to separate mongodb collection.
+            const pwdResetRequest = await _createPwdResetRequest({username: username, email: email})
+            if (pwdResetRequest.err) {
+                return res.status(400).json({message: 'Could not create a password reset request!', success:false})
+            }
+            console.log(pwdResetRequest)
+            // the .id getter returns a string containing the mongoDB document id
+            const requestId = pwdResetRequest.id
+            // document added to mongodb collection
+            const frontendUrl = process.env.FRONTEND_URL
+            const pwdResetUrl = frontendUrl + "/" + requestId
+            // const emailMessage = generateEmailMessage('zhen.teng@hotmail.com', username, pwdResetUrl)
+            const emailMessage = generateEmailMessage(email, pwdResetUrl)
+            try {
+                await sgMail.send(emailMessage)
+                console.log('Test email sent successfully');
+            } catch (error) {
+                console.error('Error sending test email');
+                console.error(error);
+                if (error.response) {
+                    console.error(error.response.body)
+                }
+            }
+            console.log(pwdResetUrl)
+            console.log(emailMessage)
+        } else {
+            return res.status(404).json({message: 'User does not exist!', success:false});
+        }
+        
+    }
+    
+}

--- a/user-service/controller/pwd-reset-controller.js
+++ b/user-service/controller/pwd-reset-controller.js
@@ -43,7 +43,6 @@ export async function sendPasswordResetEmail(req, res) {
             if (pwdResetRequest.err) {
                 return res.status(400).json({message: 'Could not create a password reset request!', success:false})
             }
-            console.log(pwdResetRequest)
             // the .id getter returns a string containing the mongoDB document id
             const requestId = pwdResetRequest.id
             // document added to mongodb collection
@@ -62,7 +61,6 @@ export async function sendPasswordResetEmail(req, res) {
                 }
             }
             console.log(pwdResetUrl)
-            console.log(emailMessage)
         } else {
             return res.status(404).json({message: 'User does not exist!', success:false});
         }

--- a/user-service/controller/pwd-reset-controller.js
+++ b/user-service/controller/pwd-reset-controller.js
@@ -53,14 +53,16 @@ export async function sendPasswordResetEmail(req, res) {
             try {
                 await sgMail.send(emailMessage)
                 console.log('Test email sent successfully');
+                console.log("reset ID: " + requestId)
+                return res.status(200).json({username: username, message: `Password reset email sent for user ${username} successfully!`, success:true})
             } catch (error) {
                 console.error('Error sending test email');
                 console.error(error);
                 if (error.response) {
                     console.error(error.response.body)
                 }
+                return res.status(400).json({message: "Error sending password reset email.", success:false})
             }
-            console.log(pwdResetUrl)
         } else {
             return res.status(404).json({message: 'User does not exist!', success:false});
         }

--- a/user-service/controller/user-controller.js
+++ b/user-service/controller/user-controller.js
@@ -140,14 +140,18 @@ export async function updatePassword(req, res) {
 
 export async function resetPassword(req, res) {
     try {
+        const username = req.body.username
         const resetId = req.body.resetId
         const newPassword = req.body.newPassword
-        if (resetId && newPassword) {
+        if (resetId && newPassword && username) {
             const pwdResetRequest = await _getPwdResetRequest(resetId)
             if (pwdResetRequest === null) {
                 return res.status(401).json({message: "Password Reset Reset ID invalid, does not exist in database", success:false})
             }
-            const username = pwdResetRequest.username
+            const existingUsername = pwdResetRequest.username
+            if (existingUsername != username) {
+                return res.status(400).json({message: "Invalid username for this request Id", success:false})
+            }
             const updatedUser = await _updatePassword(username, newPassword)
             if (updatedUser === null) {
                 return res.status(500).json({message: "Error updating user in database", success:false})

--- a/user-service/controller/user-controller.js
+++ b/user-service/controller/user-controller.js
@@ -3,6 +3,7 @@ import { ormGetUser as _getUser } from '../model/user-orm.js'
 import { ormDeleteUser as _deleteUser } from '../model/user-orm.js'
 import { ormUpdatePassword as _updatePassword } from '../model/user-orm.js'
 import { generateRefreshToken, generateAccessToken } from './user-token-handler.js'
+import { ormGetPwdResetRequest as _getPwdResetRequest } from '../model/pwd-reset-orm.js'
 import bcrypt from 'bcrypt'
 import jwt from 'jsonwebtoken'
 
@@ -139,24 +140,14 @@ export async function updatePassword(req, res) {
 
 export async function resetPassword(req, res) {
     try {
-        const username = req.body.username
+        const resetId = req.body.resetId
         const newPassword = req.body.newPassword
-        const email = req.body.email
-        if (username && email && newPassword) {
-            if (!emailRegex.test(email)) {
-                return res.status(400).json({message: 'Could not reset password, email format invalid. Email has to contain the @ and . character', success:false});
+        if (resetId && newPassword) {
+            const pwdResetRequest = await _getPwdResetRequest(resetId)
+            if (pwdResetRequest === null) {
+                return res.status(401).json({message: "Password Reset Reset ID invalid, does not exist in database", success:false})
             }
-            const existingUser = await _getUser(username)
-            var userEmail
-            if (existingUser) {
-                userEmail = existingUser.email
-                if (!userEmail) {
-                    return res.status(500).json({message: "No email address for specified user", success:false})
-                }
-                if (userEmail != email) {
-                    return res.status(400).json({message: "Email address does not match database records", success:false})
-                }
-            }
+            const username = pwdResetRequest.username
             const updatedUser = await _updatePassword(username, newPassword)
             if (updatedUser === null) {
                 return res.status(500).json({message: "Error updating user in database", success:false})

--- a/user-service/index.js
+++ b/user-service/index.js
@@ -16,6 +16,7 @@ app.get("/", (req, res) => res.send("Hello World from user-service"))
 
 import { createUser, loginUser, deleteUser, updatePassword, resetPassword } from './controller/user-controller.js';
 import { validateAccessToken, renewAccessAndRefreshTokens, invalidateRefreshToken } from './controller/user-token-handler.js';
+import { sendPasswordResetEmail } from './controller/pwd-reset-controller.js';
 
 const router = express.Router()
 
@@ -29,6 +30,7 @@ router.post('/logout', invalidateRefreshToken)
 router.delete('/delete', deleteUser)
 router.put('/updatepassword', updatePassword)
 router.put('/resetpassword', resetPassword)
+router.post('/sendresetlink', sendPasswordResetEmail)
 
 app.use('/api/user', router)
 

--- a/user-service/model/pwd-reset-model.js
+++ b/user-service/model/pwd-reset-model.js
@@ -1,0 +1,14 @@
+import mongoose from 'mongoose';
+var Schema = mongoose.Schema
+export let PwdResetSchema = new Schema({
+    username: {
+        type: String,
+        required: true,
+    },
+    email: {
+        type: String,
+        required: true,
+    }
+})
+
+export default mongoose.model('PwdResetModel', PwdResetSchema)

--- a/user-service/model/pwd-reset-orm.js
+++ b/user-service/model/pwd-reset-orm.js
@@ -1,0 +1,17 @@
+import { createPwdResetRequest, getPwdResetRequest } from "./repository.js";
+
+export async function ormCreatePwdResetRequest(params) {
+    try {
+        let pwdResetRequest = await createPwdResetRequest(params)
+        pwdResetRequest.save()
+        return pwdResetRequest
+    } catch (err) {
+        console.log('ERROR: Could not create new password reset request');
+        return { err };
+    }
+}
+
+export async function ormGetPwdResetRequest(documentId) {
+    let pwdResetRequest = await getPwdResetRequest(documentId)
+    return pwdResetRequest
+}

--- a/user-service/model/repository.js
+++ b/user-service/model/repository.js
@@ -1,4 +1,5 @@
 import UserModel from './user-model.js';
+import PwdResetModel from './pwd-reset-model.js';
 import 'dotenv/config'
 
 //Set up mongoose connection
@@ -28,9 +29,18 @@ export async function updatePassword(username, newPassword) {
   return updatedUser
 }
 
-
 export async function createUser(params) {
   //UserModel schema defines username to be unique, hence no duplicate usernames will exist.
   let userModelDocument = new UserModel(params)
   return userModelDocument
+}
+
+export async function createPwdResetRequest(params) {
+  let pwdResetDocument = new PwdResetModel(params)
+  return pwdResetDocument
+}
+
+export async function getPwdResetRequest(documentId) {
+  let pwdResetRequest = await PwdResetModel.findOneAndDelete({_id: documentId}).exec()
+  return pwdResetRequest
 }

--- a/user-service/package-lock.json
+++ b/user-service/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@sendgrid/mail": "^7.7.0",
         "bcrypt": "^5.0.1",
         "cors": "^2.8.5",
         "dotenv": "^16.0.1",
@@ -67,6 +68,41 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@sendgrid/client": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-7.7.0.tgz",
+      "integrity": "sha512-SxH+y8jeAQSnDavrTD0uGDXYIIkFylCo+eDofVmZLQ0f862nnqbC3Vd1ej6b7Le7lboyzQF6F7Fodv02rYspuA==",
+      "dependencies": {
+        "@sendgrid/helpers": "^7.7.0",
+        "axios": "^0.26.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >=10.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-7.7.0.tgz",
+      "integrity": "sha512-3AsAxfN3GDBcXoZ/y1mzAAbKzTtUZ5+ZrHOmWQ279AuaFXUNCh9bPnRpN504bgveTqoW+11IzPg3I0WVgDINpw==",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-7.7.0.tgz",
+      "integrity": "sha512-5+nApPE9wINBvHSUxwOxkkQqM/IAAaBYoP9hw7WwgDNQPxraruVqHizeTitVtKGiqWCKm2mnjh4XGN3fvFLqaw==",
+      "dependencies": {
+        "@sendgrid/client": "^7.7.0",
+        "@sendgrid/helpers": "^7.7.0"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >=10.*"
       }
     },
     "node_modules/@types/node": {
@@ -223,6 +259,14 @@
       "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/balanced-match": {
@@ -628,6 +672,14 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -862,6 +914,25 @@
       "dev": true,
       "bin": {
         "flat": "cli.js"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/forwarded": {
@@ -2580,6 +2651,32 @@
         }
       }
     },
+    "@sendgrid/client": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-7.7.0.tgz",
+      "integrity": "sha512-SxH+y8jeAQSnDavrTD0uGDXYIIkFylCo+eDofVmZLQ0f862nnqbC3Vd1ej6b7Le7lboyzQF6F7Fodv02rYspuA==",
+      "requires": {
+        "@sendgrid/helpers": "^7.7.0",
+        "axios": "^0.26.0"
+      }
+    },
+    "@sendgrid/helpers": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-7.7.0.tgz",
+      "integrity": "sha512-3AsAxfN3GDBcXoZ/y1mzAAbKzTtUZ5+ZrHOmWQ279AuaFXUNCh9bPnRpN504bgveTqoW+11IzPg3I0WVgDINpw==",
+      "requires": {
+        "deepmerge": "^4.2.2"
+      }
+    },
+    "@sendgrid/mail": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-7.7.0.tgz",
+      "integrity": "sha512-5+nApPE9wINBvHSUxwOxkkQqM/IAAaBYoP9hw7WwgDNQPxraruVqHizeTitVtKGiqWCKm2mnjh4XGN3fvFLqaw==",
+      "requires": {
+        "@sendgrid/client": "^7.7.0",
+        "@sendgrid/helpers": "^7.7.0"
+      }
+    },
     "@types/node": {
       "version": "18.0.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.6.tgz",
@@ -2702,6 +2799,14 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
     },
     "balanced-match": {
       "version": "1.0.2",
@@ -2994,6 +3099,11 @@
         "type-detect": "^4.0.0"
       }
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
+    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -3181,6 +3291,11 @@
       "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "forwarded": {
       "version": "0.2.0",

--- a/user-service/package.json
+++ b/user-service/package.json
@@ -18,6 +18,7 @@
     "nodemon": "^2.0.19"
   },
   "dependencies": {
+    "@sendgrid/mail": "^7.7.0",
     "bcrypt": "^5.0.1",
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",


### PR DESCRIPTION
API updated in api doc https://docs.google.com/document/d/1cu4jaYwPzoyUrNiOD6AaImHgAadsnrkkExGqU0219UM/edit?usp=sharing

**MSS**

- Frontend calls user-service “\api\user\sendresetlink” api, attaching username and email in request body.
- User service checks records to determine if email was registered under user
- Assuming email is registered, create entry in separate mongodb collection containing reset requests
- Store username, email and a request id
- Generate frontend url with reset id appended at end
- Send url to user in email(assuming email used to register is a real email address that receives emails)
- User clicks and accesses frontend
- Frontend extracts the request id from the url and calls the “\resetpassword\” user-service api, attaching username(again for verification purposes), new password and reset id.
- User service queries MongoDB reset requests collection and deletes it upon successful find.
- If exist, execute the reset on the users collection
- Return success.

Requires the following manual configurations:

1. Add the following lines in the .env file placed within the user-service directory
SENDGRID_API_KEY=<SENDGRID API KEY, shared in telegram group chat>
USER_SVC_SENDER_EMAIL=cs3219.project.ay2223s1.g27@gmail.com
FRONTEND_URL=<Insert full url to frontend microservice here, the reset id will be appended to the end of this url before being emailed to user for password reset>