### PR TITLE
Add axios interceptors

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,8 +7,12 @@ import MatchingPage from "./components/MatchingPage";
 import {Box} from "@mui/material"; 
 import { PrivateRoute } from "./components/PrivateRoute";
 import RoomPage from "./components/RoomPage";
+import { initAxiosApiInstance } from "./axiosApiInstance";
+import { useCookies } from "react-cookie";
  
-function App() {  
+function App() {
+    const [cookies, setCookie] = useCookies();
+    initAxiosApiInstance(cookies, setCookie);
     return (
         <div className="App">
             {/* <NavigationBar isAuthenticated={true}/> */}

--- a/frontend/src/axiosApiInstance.js
+++ b/frontend/src/axiosApiInstance.js
@@ -1,0 +1,53 @@
+import axios from "axios";
+import { URL_USER_SVC_REFRESH_TOKEN } from "./configs";
+import { jwtDecode } from "./util/auth";
+
+const axiosApiInstance = axios.create();
+
+const refreshAccessToken = async (cookies, setCookie) => {
+  const refresh_token = cookies.refresh_token;
+  if (!refresh_token) return;
+
+  const res = await axios.post(URL_USER_SVC_REFRESH_TOKEN, {username: jwtDecode(refresh_token).username}, {
+    headers: {
+        Authorization: 'Bearer ' + refresh_token
+    }
+  })
+
+  if (!res.data) return;
+
+  // set cookies
+  setCookie("access_token", res.data.accessToken);
+  setCookie("refresh_token", res.data.refreshToken);
+  return res.data.accessToken;
+}
+
+export const initAxiosApiInstance = (cookies, setCookie) => {
+  // Request interceptor for API calls
+  axiosApiInstance.interceptors.request.use(
+    async config => {
+      config.headers = { 
+        'Authorization': `Bearer ${cookies.access_token}`,
+      }
+      return config;
+    },
+    error => {
+      Promise.reject(error)
+  });
+  
+  // Response interceptor for API calls
+  axiosApiInstance.interceptors.response.use((response) => {
+    return response
+  }, async function (error) {
+    const originalRequest = error.config;
+    if (error.response.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      const access_token = await refreshAccessToken(cookies, setCookie);            
+      axios.defaults.headers.common['Authorization'] = 'Bearer ' + access_token;
+      return axiosApiInstance(originalRequest);
+    }
+    return Promise.reject(error);
+  });
+}
+
+export default axiosApiInstance;

--- a/frontend/src/components/LandingPage.js
+++ b/frontend/src/components/LandingPage.js
@@ -3,7 +3,7 @@ import {
     Button,
     Typography
 } from "@mui/material";
-import {useState} from "react";
+import { useState } from "react";
 import GroupIcon from '@mui/icons-material/Group'; 
 import NavigationBar from "./NavigationBar";  
 import { useNavigate } from "react-router-dom";

--- a/frontend/src/components/LoginPage.js
+++ b/frontend/src/components/LoginPage.js
@@ -36,7 +36,7 @@ function LoginPage() {
     const [isEmailValid, setIsEmailValid] = useState(null); 
     const [resetPasswordFailed, setResetPasswordFailed] = useState(null);  
     const [resetPasswordMessage, setResetPasswordMessage] = useState(""); 
-    const [cookies, setCookie] = useCookies(['access_token']);
+    const [cookies, setCookie] = useCookies();
 
     /** Reset Password Logic */
     const handleDialog = () => {  

--- a/frontend/src/components/MatchingPage.js
+++ b/frontend/src/components/MatchingPage.js
@@ -35,14 +35,14 @@ const buttonStyle = {
 function MatchingPage() { 
     const location = useLocation(); // Location contains username and selected difficulty level
     const navigate = useNavigate();
-    const [cookies] = useCookies(['access_token']);
+    const [cookies] = useCookies();
     const socket = io(URL_MATCHING_SVC, { 
         transports: ['websocket'],
         path: PREFIX_MATCHING_SVC
     });
 
     // Emit matching event here
-    socket.emit('match', { username: jwtDecode(cookies['access_token']).username, difficulty: location.state.difficultyLevel });
+    socket.emit('match', { username: jwtDecode(cookies['refresh_token']).username, difficulty: location.state.difficultyLevel });
     
     // Listen to matchSuccess event
     socket.once('matchSuccess', (data) => {

--- a/frontend/src/components/NavigationBar.js
+++ b/frontend/src/components/NavigationBar.js
@@ -33,7 +33,7 @@ const modalStyle = {
 
 function NavigationBar({ isAuthenticated }) {
     const navigate = useNavigate();
-    const [cookies,,removeCookie] = useCookies(["access_token", "refresh_token"]); 
+    const [cookies,,removeCookie] = useCookies(); 
     const [anchorEl, setAnchorEl] = useState(null);
     const [changePassword, setChangePassword] = useState(false);
     const [newPassword, setNewPassword] = useState("");
@@ -59,16 +59,6 @@ function NavigationBar({ isAuthenticated }) {
     }; 
     
     const handleLogOut = async () => {
-        const refresh_token = cookies["refresh_token"]
-        axios.post(URL_USER_SVC_LOGOUT, {username: jwtDecode(refresh_token).username}, {
-            headers: {
-                Authorization: 'Bearer ' + refresh_token
-            }
-        }).then(x => {
-            navigate("/login")
-        })
-        removeCookie("access_token");
-        removeCookie("refresh_token");
         setAnchorEl(null);
         setLogOut(true); 
     } 
@@ -92,6 +82,21 @@ function NavigationBar({ isAuthenticated }) {
     } 
 
     const handleDeleteAccountOnClick = () => {
+        const refresh_token = cookies["refresh_token"]
+        axios.post(URL_USER_SVC_LOGOUT, {username: jwtDecode(refresh_token).username}, {
+            headers: {
+                Authorization: 'Bearer ' + refresh_token
+            }
+        }).then(x => {
+            removeCookie("access_token");
+            removeCookie("refresh_token");
+            navigate("/login");
+        }).catch(err => {
+            console.log(err);
+            removeCookie("access_token");
+            removeCookie("refresh_token");
+            navigate("/login");
+        })
         setAnchorEl(null);
     }
 
@@ -206,7 +211,7 @@ function NavigationBar({ isAuthenticated }) {
                                             Do you wish to end your session? 
                                         </Typography>
                                         <Box display={"flex"} flexDirection={"row"} justifyContent={"flexStart"} style={{ paddingTop: "5%"}}>
-                                            <Button variant={"contained"} href='/login' onClick={handleDeleteAccountOnClick}>Back to Login Page</Button>
+                                            <Button variant={"contained"} onClick={handleDeleteAccountOnClick}>Back to Login Page</Button>
                                         </Box>
                                     </Box>
                                 </Modal> 

--- a/frontend/src/util/auth.js
+++ b/frontend/src/util/auth.js
@@ -1,26 +1,11 @@
-import axios from "axios";
-import {URL_USER_SVC_REFRESH_TOKEN} from "../configs";
-
-function getCookie(name) {
-    const value = `; ${document.cookie}`;
-    const parts = value.split(`; ${name}=`);
-    if (parts.length === 2) return parts.pop().split(';').shift();
-}
-
 export function jwtDecode(t) {
+    if (!t) {
+        console.error("t is undefined")
+        return "";
+    }
     let token = {};
     token.raw = t;
     token.header = JSON.parse(window.atob(t.split('.')[0]));
     token.payload = JSON.parse(window.atob(t.split('.')[1]));
     return token.payload
-}
-
-export function refreshJwt() {
-    const refresh_token = getCookie("refresh_token")
-    if (!refresh_token) return
-    axios.post(URL_USER_SVC_REFRESH_TOKEN, {username: jwtDecode(refresh_token).username}, {
-        headers: {
-            Authorization: 'Bearer ' + refresh_token
-        }
-    })
 }

--- a/user-service/controller/user-token-handler.js
+++ b/user-service/controller/user-token-handler.js
@@ -27,7 +27,7 @@ export function generateAccessToken(username) {
 
 export function generateRefreshToken(username) {
     try {
-        const refreshToken = jwt.sign({username: username}, jwtRefreshSecretKey, {expiresIn: "20m"})
+        const refreshToken = jwt.sign({username: username}, jwtRefreshSecretKey, {expiresIn: "24h"})
         refreshTokens.push(refreshToken)
         return refreshToken
     } catch (err) {


### PR DESCRIPTION
In the future, use `axiosApiInstance` when making API calls to authenticated endpoints.

1. This will automatically try to get new access token if `401` is received as a response.
2. The jwt token is also automatically added to the header if we are using axiosApiInstance, so an API call will look like this (no need to manually set jwt inside the header)
```
        axiosApiInstance.get(AUTHENTICATED_ENDPOINT).then(x => {
            setText(x.data)
        })
```