### PR TITLE
Fix react cookie

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -12,8 +12,8 @@ import { useCookies } from "react-cookie";
 import { PREFIX_FRONTEND_LANDING, PREFIX_FRONTEND_LOGIN, PREFIX_FRONTEND_MATCHING, PREFIX_FRONTEND_ROOM, PREFIX_FRONTEND_ROOT, PREFIX_FRONTEND_SIGNUP } from "./configs";
  
 function App() {
-    const [cookies, setCookie] = useCookies();
-    initAxiosApiInstance(cookies, setCookie);
+    const [, setCookie] = useCookies();
+    initAxiosApiInstance(setCookie);
     return (
         <div className="App">
             {/* <NavigationBar isAuthenticated={true}/> */}


### PR DESCRIPTION
This closes #65 

This issue arises because react cookie can't be used outside of a component, see [here](https://stackoverflow.com/questions/45708003/using-react-cookie-in-a-util-file).

Hence, the old implementation passed the cookie from a component out to a util file.

However, when we read the cookie before sending a request, we are reading the old version of the cookie (the cookie that got passed down when the axios is initialized), hence we get undefined.

In the new implementation, we directly read from global document.cookie, so the data we get is up to date.
