### PR TITLE
Fix room disconnect on browser close

### DIFF
--- a/frontend/src/components/RoomPage.js
+++ b/frontend/src/components/RoomPage.js
@@ -56,6 +56,15 @@ function RoomPage() {
     setAnchorEl(null);
   }
 
+  const unloadCallback = (event) => {
+    event.stopImmediatePropagation();
+    event.returnValue = "";
+    sendSocketLeave();
+    return "";
+  };
+
+  window.addEventListener("beforeunload", unloadCallback);
+
   const codeEditorSocket = io(URL_COLLAB_SVC, {
     transports: ['websocket'],
     path: PREFIX_COLLAB_SVC,
@@ -63,6 +72,10 @@ function RoomPage() {
       token: `Bearer ${cookies['access_token']}`
     }
   });
+
+  const sendSocketLeave = () => {
+    codeEditorSocket.emit('leave room', { room_id: location.state.room_id, username: jwtDecode(cookies['refresh_token']).username });
+  }
 
   useEffect(() => {
     // console.log(location.state.difficultyLevel)
@@ -79,7 +92,8 @@ function RoomPage() {
     })
 
     return () => { // component will unmount equivalent
-      codeEditorSocket.emit('leave room', { room_id: location.state.room_id, username: jwtDecode(cookies['refresh_token']).username });
+      sendSocketLeave();
+      window.removeEventListener('beforeunload', unloadCallback);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])


### PR DESCRIPTION
This fixes #78. When browser closes, disconnect messages will be sent too. `event.stopImmediatePropagation()` prevents the socket from closing immediately

[Reference](https://github.com/socketio/engine.io-client/issues/658)